### PR TITLE
Publish to Github container registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,9 +6,7 @@ on:
             - main
 
 env:
-    DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-    DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-    IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/blockgauge
+    IMAGE_NAME: ghcr.io/${{ github.repository_owner}}/blockgauge
 
 jobs:
     # Extract the VERSION which is either `latest` or `vX.Y.Z`, and the VERSION_SUFFIX
@@ -44,7 +42,7 @@ jobs:
             - uses: docker/setup-qemu-action@v2
             - name: Dockerhub login
               run: |
-                  echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+                  echo "${ secrets.GITHUB_TOKEN }" | docker login ghcr.io --username ${ github.repository_owner} --password-stdin
             - name: Map x86_64 to amd64 short arch
               run: echo "SHORT_ARCH=amd64" >> $GITHUB_ENV;
             - name: Build Dockerfile and push


### PR DESCRIPTION
DockerHub requires paid registration for organisations, so this PR moves the `blockgauge` image to the GitHub container registry: `ghcr.io/blockprint-collective/blockgauge`.